### PR TITLE
사용자 조회 동작 추가

### DIFF
--- a/src/main/kotlin/org/example/hhpluscleanarchitecture/user/domain/User.kt
+++ b/src/main/kotlin/org/example/hhpluscleanarchitecture/user/domain/User.kt
@@ -1,0 +1,6 @@
+package org.example.hhpluscleanarchitecture.user.domain
+
+class User (
+    val id: Long,
+    val name: String,
+)

--- a/src/main/kotlin/org/example/hhpluscleanarchitecture/user/repository/UserEntity.kt
+++ b/src/main/kotlin/org/example/hhpluscleanarchitecture/user/repository/UserEntity.kt
@@ -1,0 +1,24 @@
+package org.example.hhpluscleanarchitecture.user.repository
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import org.example.hhpluscleanarchitecture.user.domain.User
+
+@Entity(name = "user")
+data class UserEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) val id: Long,
+    @Column(nullable = false) var name: String,
+) {
+    companion object {
+        fun fromUser(user: User): UserEntity {
+            return UserEntity(user.id, user.name)
+        }
+    }
+
+    fun toDomainModel(): User {
+        return User(id, name)
+    }
+}

--- a/src/main/kotlin/org/example/hhpluscleanarchitecture/user/repository/UserJpaRepository.kt
+++ b/src/main/kotlin/org/example/hhpluscleanarchitecture/user/repository/UserJpaRepository.kt
@@ -1,0 +1,5 @@
+package org.example.hhpluscleanarchitecture.user.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserJpaRepository : JpaRepository<UserEntity, Long>

--- a/src/main/kotlin/org/example/hhpluscleanarchitecture/user/repository/UserRepositoryImpl.kt
+++ b/src/main/kotlin/org/example/hhpluscleanarchitecture/user/repository/UserRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package org.example.hhpluscleanarchitecture.user.repository
+
+import org.example.hhpluscleanarchitecture.user.domain.User
+import org.example.hhpluscleanarchitecture.user.service.UserRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Repository
+import kotlin.jvm.optionals.getOrNull
+
+@Repository
+class UserRepositoryImpl(@Autowired private val userJpaRepository: UserJpaRepository): UserRepository {
+    override fun findById(id: Long): User? {
+        return userJpaRepository.findById(id).getOrNull()?.toDomainModel()
+    }
+}

--- a/src/main/kotlin/org/example/hhpluscleanarchitecture/user/service/UserRepository.kt
+++ b/src/main/kotlin/org/example/hhpluscleanarchitecture/user/service/UserRepository.kt
@@ -1,0 +1,7 @@
+package org.example.hhpluscleanarchitecture.user.service
+
+import org.example.hhpluscleanarchitecture.user.domain.User
+
+interface UserRepository {
+    fun findById(id: Long): User?
+}

--- a/src/main/kotlin/org/example/hhpluscleanarchitecture/user/service/UserService.kt
+++ b/src/main/kotlin/org/example/hhpluscleanarchitecture/user/service/UserService.kt
@@ -1,0 +1,11 @@
+package org.example.hhpluscleanarchitecture.user.service
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class UserService(@Autowired private val userRepository: UserRepository) {
+    fun checkUserExists(id: Long): Boolean {
+        return userRepository.findById(id) != null
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,7 @@
+INSERT INTO
+    `user`
+VALUES
+    (1, 'Kim'),
+    (2, 'Lee'),
+    (3, 'Park')
+;

--- a/src/test/kotlin/org/example/hhpluscleanarchitecture/user/repository/UserRepositoryImplTest.kt
+++ b/src/test/kotlin/org/example/hhpluscleanarchitecture/user/repository/UserRepositoryImplTest.kt
@@ -1,0 +1,48 @@
+package org.example.hhpluscleanarchitecture.user.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.example.hhpluscleanarchitecture.user.domain.User
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+class UserRepositoryImplTest {
+
+    companion object {
+        const val USER_ID : Long = 1
+        const val USER_NAME = "John Doe"
+        val USER_ENTITY = UserEntity(USER_ID, USER_NAME)
+        val USER = User(id = USER_ID, name = USER_NAME)
+    }
+
+    @Mock
+    private lateinit var userJpaRepository: UserJpaRepository
+
+    @InjectMocks
+    private lateinit var userRepositoryImpl: UserRepositoryImpl
+
+    @Test
+    fun `응답한 결과가 존재하면 도메인 객체로 전환하여 반환한다`() {
+        `when`(userJpaRepository.findById(eq(USER_ID))).thenReturn(Optional.of(USER_ENTITY))
+
+        val result = userRepositoryImpl.findById(USER_ID)
+
+        assertThat(result!!).usingRecursiveComparison().isEqualTo(USER)
+    }
+
+    @Test
+    fun `응답한 결과가 존재하지 않으면 null을 반환한다`() {
+        `when`(userJpaRepository.findById(eq(USER_ID))).thenReturn(Optional.empty())
+
+        val result = userRepositoryImpl.findById(USER_ID)
+
+        assertThat(result).isNull()
+    }
+}

--- a/src/test/kotlin/org/example/hhpluscleanarchitecture/user/service/UserServiceTest.kt
+++ b/src/test/kotlin/org/example/hhpluscleanarchitecture/user/service/UserServiceTest.kt
@@ -1,0 +1,46 @@
+package org.example.hhpluscleanarchitecture.user.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.example.hhpluscleanarchitecture.user.domain.User
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class UserServiceTest {
+    companion object {
+        const val USER_ID : Long = 1
+        const val USER_NAME = "John Doe"
+        val USER = User(id = USER_ID, name = USER_NAME)
+    }
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @InjectMocks
+    private lateinit var userService: UserService
+
+    @Test
+    fun `유저가 있는 경우 true를 반환한다`() {
+        `when`(userRepository.findById(eq(USER_ID))).thenReturn(USER)
+
+        val result = userService.checkUserExists(USER_ID)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `유저가 없는 경우 false를 반환한다`() {
+        `when`(userRepository.findById(eq(USER_ID))).thenReturn(null)
+
+        val result = userService.checkUserExists(USER_ID)
+
+        assertThat(result).isFalse()
+    }
+}


### PR DESCRIPTION
- UserRepositoryImpl은 JpaRepository를 주입받아 Entity를 검색후 이를 도매인 객체로 반환합니다.
- UserService 에서는 UserRepository를 주입받아 전달받은 id의 회원이 존재하는지 확인하는 동작을 수행합니다.
- 로컬에서 기본으로 사용할 이용자 정보 추가했습니다.